### PR TITLE
Allow the base URL to be configurable for testing, including leaving out the version identifier

### DIFF
--- a/lib/pexels.rb
+++ b/lib/pexels.rb
@@ -1,8 +1,9 @@
 module Pexels
-  @api_base_url = 'https://api.pexels.com'
+  @api_base_url = ENV['PEXELS_API_BASE_URL'] || 'https://api.pexels.com'
+  @api_version = ENV['PEXELS_API_VERSION'] || 'v1'
 
   class << self
-    attr_reader :api_base_url
+    attr_reader :api_base_url, :api_version
   end
 end
 

--- a/lib/pexels/client.rb
+++ b/lib/pexels/client.rb
@@ -18,9 +18,12 @@ class Pexels::Client
   end
 
   def request(path, method: 'GET', params: {})
+    url = File.join(Pexels.api_base_url, path)
+    puts "Requesting #{url}" if ENV['DEBUG']
+
     results = Requests.request(
       method,
-      "#{Pexels.api_base_url}#{path}",
+      url,
       params: params,
       headers: {
         'Authorization' => api_key

--- a/lib/pexels/client/photos.rb
+++ b/lib/pexels/client/photos.rb
@@ -5,14 +5,14 @@ class Pexels::Client::Photos
   end
 
   def [](id)
-    response = @client.request("/v1/photos/#{id}")
+    response = @client.request("#{Pexels.api_version}/photos/#{id}")
     Pexels::Photo.new(response)
   end
   alias_method :find, :[]
 
   def search(query, per_page: 15, page: 1, locale: 'en-US')
     response = @client.request(
-      '/v1/search',
+      "#{Pexels.api_version}/search",
       params: {
         query: query,
         per_page: per_page,
@@ -26,7 +26,7 @@ class Pexels::Client::Photos
 
   def curated(per_page: 15, page: 1)
     response = @client.request(
-      '/v1/curated',
+      "#{Pexels.api_version}/curated",
       params: {
         per_page: per_page,
         page: page,


### PR DESCRIPTION
Also added a bit of debug output when `ENV['DEBUG']` is set.