### PR TITLE
Expose timeout options

### DIFF
--- a/lib/pexels/client.rb
+++ b/lib/pexels/client.rb
@@ -19,8 +19,8 @@ module Pexels
       @collections ||= Pexels::Client::Collections.new(self)
     end
 
-    def request(path, method: 'GET', params: {})
-      request = Request.new(api_key, path, method, params)
+    def request(path, method: 'GET', params: {}, options: {})
+      request = Request.new(api_key, path, method, params, options)
       request.call.tap do |response|
         @ratelimit_remaining = response.ratelimit_remaining
       end

--- a/lib/pexels/client/collections.rb
+++ b/lib/pexels/client/collections.rb
@@ -3,35 +3,47 @@ class Pexels::Client::Collections
     @client = client
   end
 
-  def all(per_page: 15, page: 1)
+  def all(per_page: 15, page: 1, timeout: { open: nil, read: nil })
     response = @client.request(
       "#{Pexels.api_version}/collections",
       params: {
         per_page: per_page,
         page: page
+      },
+      options: {
+        open_timeout: timeout[:open],
+        read_timeout: timeout[:read]
       })
 
     Pexels::CollectionSet.new(response)
   end
 
-  def featured(per_page: 15, page: 1)
+  def featured(per_page: 15, page: 1, timeout: { open: nil, read: nil })
     response = @client.request(
       "#{Pexels.api_version}/collections/featured",
       params: {
         per_page: per_page,
         page: page
+      },
+      options: {
+        open_timeout: timeout[:open],
+        read_timeout: timeout[:read]
       })
 
     Pexels::CollectionSet.new(response)
   end
 
-  def [](id, type: nil, per_page: 15, page: 1)
+  def [](id, type: nil, per_page: 15, page: 1, timeout: { open: nil, read: nil })
     response = @client.request(
       "#{Pexels.api_version}/collections/#{id}",
       params: {
         per_page: per_page,
         page: page,
         type: type
+      },
+      options: {
+        open_timeout: timeout[:open],
+        read_timeout: timeout[:read]
       })
 
     Pexels::CollectionMediaSet.new(response)

--- a/lib/pexels/client/photos.rb
+++ b/lib/pexels/client/photos.rb
@@ -7,13 +7,16 @@ module Pexels
         @client = client
       end
 
-      def [](id)
-        response = @client.request("#{Pexels.api_version}/photos/#{id}")
+      def [](id, timeout: { open: nil, read: nil })
+        response = @client.request(
+          "#{Pexels.api_version}/photos/#{id}",
+          options: { open_timeout: timeout[:open], read_timeout: timeout[:read] }
+        )
         Pexels::Photo.new(response.body)
       end
       alias_method :find, :[]
 
-      def search(query, per_page: 15, page: 1, locale: 'en-US', orientation: nil, size: nil, color: nil)
+      def search(query, per_page: 15, page: 1, locale: 'en-US', orientation: nil, size: nil, color: nil, timeout: { open: nil, read: nil })
         validate_search_params(orientation, size, color)
 
         response = @client.request(
@@ -26,18 +29,26 @@ module Pexels
             orientation: orientation,
             size: size,
             color: color
-          }.compact
+          }.compact,
+          options: {
+            open_timeout: timeout[:open],
+            read_timeout: timeout[:read]
+          }
         )
 
         Pexels::PhotoSet.new(response)
       end
 
-      def curated(per_page: 15, page: 1)
+      def curated(per_page: 15, page: 1, timeout: { open: nil, read: nil })
         response = @client.request(
           "#{Pexels.api_version}/curated",
           params: {
             per_page: per_page,
             page: page
+          },
+          options: {
+            open_timeout: timeout[:open],
+            read_timeout: timeout[:read]
           }
         )
 

--- a/lib/pexels/client/request.rb
+++ b/lib/pexels/client/request.rb
@@ -3,13 +3,14 @@ require 'requests'
 module Pexels
   class Client
     class Request
-      attr_reader :api_key, :path, :method, :params
+      attr_reader :api_key, :path, :method, :params, :options
 
-      def initialize(api_key, path, method, params)
+      def initialize(api_key, path, method, params, options)
         @api_key = api_key
         @path = path
         @method = method
         @params = params
+        @options = options
       end
 
       def call
@@ -28,7 +29,8 @@ module Pexels
           method,
           url,
           params: params,
-          headers: headers
+          headers: headers,
+          options: options
         )
       end
 

--- a/lib/pexels/client/videos.rb
+++ b/lib/pexels/client/videos.rb
@@ -7,13 +7,19 @@ module Pexels
         @client = client
       end
 
-      def [](id)
-        response = @client.request("/videos/videos/#{id}")
+      def [](id, timeout: { open: nil, read: nil })
+        response = @client.request(
+          "/videos/videos/#{id}",
+          options: {
+            open_timeout: timeout[:open],
+            read_timeout: timeout[:read]
+          }
+        )
         Pexels::Video.new(response.body)
       end
       alias_method :find, :[]
 
-      def search(query, per_page: 15, page: 1, orientation: nil, size: nil)
+      def search(query, per_page: 15, page: 1, orientation: nil, size: nil, timeout: { open: nil, read: nil })
         validate_search_params(orientation, size)
 
         response = @client.request(
@@ -24,18 +30,26 @@ module Pexels
             page: page,
             orientation: orientation,
             size: size
-          }.compact
+          }.compact,
+          options: {
+            open_timeout: timeout[:open],
+            read_timeout: timeout[:read]
+          }
         )
 
         Pexels::VideoSet.new(response)
       end
 
-      def popular(per_page: 15, page: 1)
+      def popular(per_page: 15, page: 1, timeout: { open: nil, read: nil })
         response = @client.request(
           '/videos/popular',
           params: {
             per_page: per_page,
-            page: page,
+            page: page
+          },
+          options: {
+            open_timeout: timeout[:open],
+            read_timeout: timeout[:read]
           }
         )
 

--- a/test/collection_test.rb
+++ b/test/collection_test.rb
@@ -98,4 +98,52 @@ class TestCollections < Minitest::Test
     end
     assert error.message, 'Not Found'
   end
+
+  def test_get_collection_open_timeout
+    error = assert_raises Pexels::APIError do
+      @client.collections[@collection.id, timeout: { open: 0.0000001 }]
+    end
+
+    assert_equal 'execution expired', error.message
+  end
+
+  def test_get_collection_read_timeout
+    error = assert_raises Pexels::APIError do
+      @client.collections[@collection.id, timeout: { read: 0.0000001 }]
+    end
+
+    assert_equal 'Net::ReadTimeout', error.message
+  end
+
+  def test_all_open_timeout
+    error = assert_raises Pexels::APIError do
+      @client.collections.all(timeout: { open: 0.0000001 })
+    end
+
+    assert_equal 'execution expired', error.message
+  end
+
+  def test_all_read_timeout
+    error = assert_raises Pexels::APIError do
+      @client.collections.all(timeout: { read: 0.0000001 })
+    end
+
+    assert_equal 'Net::ReadTimeout', error.message
+  end
+
+  def test_featured_open_timeout
+    error = assert_raises Pexels::APIError do
+      @client.collections.featured(timeout: { open: 0.0000001 })
+    end
+
+    assert_equal 'execution expired', error.message
+  end
+
+  def test_featured_read_timeout
+    error = assert_raises Pexels::APIError do
+      @client.collections.featured(timeout: { read: 0.0000001 })
+    end
+
+    assert_equal 'Net::ReadTimeout', error.message
+  end
 end

--- a/test/photo_test.rb
+++ b/test/photo_test.rb
@@ -107,4 +107,52 @@ class TestPhoto < Minitest::Test
     assert_kind_of Pexels::PhotoSet, search_result
     assert search_result.photos.any?
   end
+
+  def test_get_photo_open_timeout
+    error = assert_raises Pexels::APIError do
+      @client.photos[@photo.id, timeout: { open: 0.0000001 }]
+    end
+
+    assert_equal 'execution expired', error.message
+  end
+
+  def test_get_photo_read_timeout
+    error = assert_raises Pexels::APIError do
+      @client.photos[@photo.id, timeout: { read: 0.0000001 }]
+    end
+
+    assert_equal 'Net::ReadTimeout', error.message
+  end
+
+  def test_search_open_timeout
+    error = assert_raises Pexels::APIError do
+      @client.photos.search('test', timeout: { open: 0.0000001 })
+    end
+
+    assert_equal 'execution expired', error.message
+  end
+
+  def test_search_read_timeout
+    error = assert_raises Pexels::APIError do
+      @client.photos.search('test', timeout: { read: 0.0000001 })
+    end
+
+    assert_equal 'Net::ReadTimeout', error.message
+  end
+
+  def test_curated_open_timeout
+    error = assert_raises Pexels::APIError do
+      @client.photos.curated(timeout: { open: 0.0000001 })
+    end
+
+    assert_equal 'execution expired', error.message
+  end
+
+  def test_curated_read_timeout
+    error = assert_raises Pexels::APIError do
+      @client.photos.curated(timeout: { read: 0.0000001 })
+    end
+
+    assert_equal 'Net::ReadTimeout', error.message
+  end
 end

--- a/test/video_test.rb
+++ b/test/video_test.rb
@@ -99,4 +99,52 @@ class TestVideo < Minitest::Test
     assert_kind_of Pexels::VideoSet, search_result
     assert search_result.videos.any?
   end
+
+  def test_get_video_open_timeout
+    error = assert_raises Pexels::APIError do
+      @client.videos[@video.id, timeout: { open: 0.0000001 }]
+    end
+
+    assert_equal 'execution expired', error.message
+  end
+
+  def test_get_video_read_timeout
+    error = assert_raises Pexels::APIError do
+      @client.videos[@video.id, timeout: { read: 0.0000001 }]
+    end
+
+    assert_equal 'Net::ReadTimeout', error.message
+  end
+
+  def test_search_open_timeout
+    error = assert_raises Pexels::APIError do
+      @client.videos.search('cat', timeout: { open: 0.0000001 })
+    end
+
+    assert_equal 'execution expired', error.message
+  end
+
+  def test_search_read_timeout
+    error = assert_raises Pexels::APIError do
+      @client.videos.search('cat', timeout: { read: 0.0000001 })
+    end
+
+    assert_equal 'Net::ReadTimeout', error.message
+  end
+
+  def test_featured_open_timeout
+    error = assert_raises Pexels::APIError do
+      @client.videos.popular(timeout: { open: 0.0000001 })
+    end
+
+    assert_equal 'execution expired', error.message
+  end
+
+  def test_featured_read_timeout
+    error = assert_raises Pexels::APIError do
+      @client.videos.popular(timeout: { read: 0.0000001 })
+    end
+
+    assert_equal 'Net::ReadTimeout', error.message
+  end
 end


### PR DESCRIPTION
**Issue**

No timeout options are available.

**Solution**

Expose read and open timeouts provided by the `requests` gem.