### PR TITLE
Add alt text to Photo

### DIFF
--- a/lib/pexels/photo.rb
+++ b/lib/pexels/photo.rb
@@ -5,7 +5,8 @@ class Pexels::Photo
               :url,
               :user,
               :src,
-              :avg_color
+              :avg_color,
+              :alt
 
   def initialize(attrs)
     @id = attrs.fetch('id')
@@ -19,7 +20,7 @@ class Pexels::Photo
     )
     @src = attrs.fetch('src')
     @avg_color = attrs.fetch('avg_color')
-
+    @alt = attrs.fetch('alt')
   rescue KeyError => exception
     raise Pexels::MalformedAPIResponseError.new(exception)
   end

--- a/test/photo_test.rb
+++ b/test/photo_test.rb
@@ -61,6 +61,7 @@ class TestPhoto < Minitest::Test
     assert_equal photo.user.id, @photo.user.id
     assert_equal photo.src, @photo.src
     assert_equal photo.avg_color, @photo.avg_color
+    assert_equal photo.alt, @photo.alt
 
     assert photo.photo?
     assert_equal photo.type, 'Photo'


### PR DESCRIPTION
Closes #9 

Adds `Photo#alt` to return the alt text for a photo.