### PR TITLE
Fix Pexels::Video::Picture#nr, add missing alt to Pexels::Photo

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 0.6.1
+* Added `alt` to `Pexels::Photo`.
+* Fixed `nr` reader in `Pexels::Video::Picture`.
+
 ## 0.6.0
 * Added `fps` to `Pexels::Video::File`.
 

--- a/lib/pexels/paginated_response.rb
+++ b/lib/pexels/paginated_response.rb
@@ -4,6 +4,8 @@ module Pexels
   class PaginatedResponse
     include Enumerable
 
+    attr_reader :response, :attrs
+
     attr_reader :total_results,
       :page,
       :per_page,
@@ -50,7 +52,6 @@ module Pexels
 
     private
 
-    attr_reader :response, :attrs
 
     def request
       response.request

--- a/lib/pexels/photo.rb
+++ b/lib/pexels/photo.rb
@@ -5,7 +5,9 @@ class Pexels::Photo
               :url,
               :user,
               :src,
-              :avg_color
+              :avg_color,
+              :alt
+
 
   def initialize(attrs)
     @id = attrs.fetch('id')
@@ -19,6 +21,7 @@ class Pexels::Photo
     )
     @src = attrs.fetch('src')
     @avg_color = attrs.fetch('avg_color')
+    @alt = attrs.fetch('alt')
 
   rescue KeyError => exception
     raise Pexels::MalformedAPIResponseError.new(exception)

--- a/lib/pexels/version.rb
+++ b/lib/pexels/version.rb
@@ -1,3 +1,3 @@
 module Pexels
-  VERSION = '0.6.1'
+  VERSION = '0.6.2'
 end

--- a/lib/pexels/version.rb
+++ b/lib/pexels/version.rb
@@ -1,3 +1,3 @@
 module Pexels
-  VERSION = '0.6.0'
+  VERSION = '0.6.1'
 end

--- a/lib/pexels/video/picture.rb
+++ b/lib/pexels/video/picture.rb
@@ -1,6 +1,6 @@
 class Pexels::Video::Picture
   attr_reader :id,
-              :picture
+              :picture,
               :nr
 
   def initialize(attrs)

--- a/test/photo_test.rb
+++ b/test/photo_test.rb
@@ -61,6 +61,7 @@ class TestPhoto < Minitest::Test
     assert_equal photo.user.id, @photo.user.id
     assert_equal photo.src, @photo.src
     assert_equal photo.avg_color, @photo.avg_color
+    assert_equal photo.alt, @photo.alt
 
     assert photo.photo?
     assert_equal photo.type, 'Photo'


### PR DESCRIPTION
Tests are updated to reflect the new "alt" property.
`Pexels::Video::Picture#nr` was broken due to a missing comma.